### PR TITLE
Typo and logic fixes in remote-ip-go post

### DIFF
--- a/_posts/2015-12-17-remote-ip-go.markdown
+++ b/_posts/2015-12-17-remote-ip-go.markdown
@@ -124,7 +124,7 @@ func getIPAdress(r *http.Request) string {
     for _, h := range []string{"X-Forwarded-For", "X-Real-Ip"} {
         for _, ip := range strings.Split(r.Header.Get(h), ",") {
             // header can contain spaces too, strip those out.
-    		ip = strings.TrimSpace(ip)
+            ip = strings.TrimSpace(ip)
             realIP := net.ParseIP(ip)
             if !realIP.IsGlobalUnicast() || isPrivateSubnet(realIP) {
                 // bad address, go to next

--- a/_posts/2015-12-17-remote-ip-go.markdown
+++ b/_posts/2015-12-17-remote-ip-go.markdown
@@ -86,8 +86,8 @@ var privateRanges = []ipRange{
         end:   net.ParseIP("100.127.255.255"),
     },
     ipRange{
-		start: net.ParseIP("172.16.0.0"),
-		end:   net.ParseIP("172.31.255.255"),
+        start: net.ParseIP("172.16.0.0"),
+        end:   net.ParseIP("172.31.255.255"),
     },
     ipRange{
         start: net.ParseIP("192.0.0.0"),

--- a/_posts/2015-12-17-remote-ip-go.markdown
+++ b/_posts/2015-12-17-remote-ip-go.markdown
@@ -79,27 +79,27 @@ func inRange(r ipRange, ipAddress net.IP) bool {
 var privateRanges = []ipRange{
     ipRange{
         start: net.ParseIP("10.0.0.0"),
-        start: net.ParseIP("10.255.255.255"),
+        end:   net.ParseIP("10.255.255.255"),
     },
     ipRange{
         start: net.ParseIP("100.64.0.0"),
-        start: net.ParseIP("100.127.255.255"),
+        end:   net.ParseIP("100.127.255.255"),
     },
     ipRange{
-        start: net.ParseIP("172.16.0.0"),
-        start: net.ParseIP("172.31.255.255"),
+		start: net.ParseIP("172.16.0.0"),
+		end:   net.ParseIP("172.31.255.255"),
     },
     ipRange{
         start: net.ParseIP("192.0.0.0"),
-        start: net.ParseIP("192.0.0.255"),
+        end:   net.ParseIP("192.0.0.255"),
     },
     ipRange{
         start: net.ParseIP("192.168.0.0"),
-        start: net.ParseIP("192.168.255.255"),
+        end:   net.ParseIP("192.168.255.255"),
     },
     ipRange{
         start: net.ParseIP("198.18.0.0"),
-        start: net.ParseIP("198.19.255.255"),
+        end:   net.ParseIP("198.19.255.255"),
     },
 }
 
@@ -107,7 +107,7 @@ var privateRanges = []ipRange{
 // isPrivateSubnet - check to see if this ip is in a private subnet
 func isPrivateSubnet(ipAddress net.IP) bool {
     // my use case is only concerned with ipv4 atm
-    ip ipCheck := ipAddress.To4(); ipCheck != nil {
+    if ipCheck := ipAddress.To4(); ipCheck != nil {
         // iterate over all our ranges
         for _, r := range privateRanges {
             // check if this ip is in a private range
@@ -124,8 +124,9 @@ func getIPAdress(r *http.Request) string {
     for _, h := range []string{"X-Forwarded-For", "X-Real-Ip"} {
         for _, ip := range strings.Split(r.Header.Get(h), ",") {
             // header can contain spaces too, strip those out.
-            realIP := net.ParseIP(strings.Replace(ip, " ", "", -1))
-            if !realIP.IsGlobalUnicast() && !isPrivateSubnet(realIP) {
+    		ip = strings.TrimSpace(ip)
+            realIP := net.ParseIP(ip)
+            if !realIP.IsGlobalUnicast() || isPrivateSubnet(realIP) {
                 // bad address, go to next
                 continue
             } else {
@@ -164,10 +165,10 @@ func getIPAdress(r *http.Request) string {
         // march from right to left until we get a public address
         // that will be the address right before our proxy.
         for i := len(addresses) -1 ; i >= 0; i-- {
-            ip := addresses[i]
+            ip := strings.TrimSpace(addresses[i])
             // header can contain spaces too, strip those out.
-            realIP := net.ParseIP(strings.Replace(ip, " ", "", -1))
-            if !realIP.IsGlobalUnicast() && !isPrivateSubnet(realIP) {
+            realIP := net.ParseIP(ip)
+            if !realIP.IsGlobalUnicast() || isPrivateSubnet(realIP) {
                 // bad address, go to next
                 continue
             }


### PR DESCRIPTION
- Return space-trimmed ip
- Contrary to the example, we're probably not interested in non-globalUnicast ip addresses
- Fix various typos
